### PR TITLE
add semantic title attributes to ControlBar links

### DIFF
--- a/app/components/ControlBar.jsx
+++ b/app/components/ControlBar.jsx
@@ -38,6 +38,7 @@ var ControlBar = React.createClass({
             event.preventDefault();
             browserHistory.push('/settings');
           }}
+          title="User settings"
         >
           Settings
         </a>
@@ -47,6 +48,7 @@ var ControlBar = React.createClass({
           onDoubleClick={this.props.handleRootRefresh}
           onTouchStart={this.detectDoubleTap}
           className="controlBar-control controlBar-title"
+          title="{this.props.title}"
         >
           {this.props.title}
         </a>
@@ -54,6 +56,7 @@ var ControlBar = React.createClass({
           className=" controlBar-control newPostControl"
           href="/topic/new"
           onClick={this.handleRightControl}
+          title="Create a new post"
         >
           New
         </a>

--- a/app/components/ControlBar.jsx
+++ b/app/components/ControlBar.jsx
@@ -48,7 +48,7 @@ var ControlBar = React.createClass({
           onDoubleClick={this.props.handleRootRefresh}
           onTouchStart={this.detectDoubleTap}
           className="controlBar-control controlBar-title"
-          title="{this.props.title}"
+          title={this.props.title}
         >
           {this.props.title}
         </a>


### PR DESCRIPTION
With accessibility in mind, added:
 - Static title attributes to the "Settings" and "New" links
 - Dynamic title attribute to `controlBar-title` link with `{this.props.title}`

Will it blend, @nchase?